### PR TITLE
Split from the right when extracting credentials

### DIFF
--- a/purl/url.py
+++ b/purl/url.py
@@ -103,7 +103,7 @@ def parse(url_str):
     """
     url_str = to_unicode(url_str)
     result = urlparse(url_str)
-    netloc_parts = result.netloc.split('@')
+    netloc_parts = result.netloc.rsplit('@', 1)
     if len(netloc_parts) == 1:
         username = password = None
         host = netloc_parts[0]

--- a/tests/url_tests.py
+++ b/tests/url_tests.py
@@ -111,6 +111,11 @@ class EdgeCaseExtractionTests(TestCase):
         url = URL.from_string('ftp://user:pw@ftp.host')
         self.assertEqual('user:pw@ftp.host', url.netloc())
 
+    def test_auth_with_special_char(self):
+        url = URL.from_string('ftp://user:b@z@ftp.host')
+        self.assertEqual('user', url.username())
+        self.assertEqual('b@z', url.password())
+
     def test_port_in_netloc(self):
         url = URL.from_string('http://localhost:5000')
         self.assertEqual('localhost', url.host())


### PR DESCRIPTION
It's important to split on the first '@' character from the right to
ensure that special characters in the password aren't interpretted as
part of the hostname.